### PR TITLE
Exclude more environments

### DIFF
--- a/plugins/gtk/lxhotkey-gtk.desktop.in
+++ b/plugins/gtk/lxhotkey-gtk.desktop.in
@@ -5,7 +5,7 @@ _Name=Setup Hot Keys
 _Comment=View and change Window Manager global shortcuts
 _Keywords=hotkey;shortcut;system;settings;
 Categories=DesktopSettings;Settings;Core;GTK;
-NotShowIn=GNOME;KDE;XFCE;MATE;
+NotShowIn=GNOME;KDE;XFCE;MATE;Budgie;COSMIC;Enlightenment;LXQt;X-Cinnamon;
 Exec=lxhotkey --gui=gtk
 StartupNotify=true
 Terminal=false


### PR DESCRIPTION
These desktop environments have their own tools to configure keyboard shortcuts.